### PR TITLE
Feat/hiervis

### DIFF
--- a/src/basic_hierarchy/common/HierarchyBuilder.java
+++ b/src/basic_hierarchy/common/HierarchyBuilder.java
@@ -3,6 +3,7 @@ package basic_hierarchy.common;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -100,10 +101,41 @@ public class HierarchyBuilder
 
         statusMsg = "Sorting...";
         progress = 0;
+
         Collections.sort( nodes, comparator );
+        sortAllChildren( root );
+
         progress = 100;
 
         return nodes;
+    }
+
+    /**
+     * Recursively sorts all children of the specified node using {@link NodeIdComparator}
+     * 
+     * @param root
+     *            the node to sort
+     */
+    public static void sortAllChildren( Node root )
+    {
+        NodeIdComparator comparator = new NodeIdComparator();
+        sortAllChildren( root, comparator );
+    }
+
+    /**
+     * Recursively sorts all children of the specified node using the specified comparator.
+     * 
+     * @param node
+     *            the node whose children are to be sorted
+     * @param comparator
+     *            the comparator to use to sort the children
+     */
+    public static void sortAllChildren( Node node, Comparator<Node> comparator )
+    {
+        Collections.sort( node.getChildren(), comparator );
+        for ( Node n : node.getChildren() ) {
+            sortAllChildren( n, comparator );
+        }
     }
 
     /**
@@ -131,7 +163,6 @@ public class HierarchyBuilder
 
             n.recalculateCentroid( useSubtree );
         }
-
     }
 
     /**

--- a/src/basic_hierarchy/common/HierarchyBuilder.java
+++ b/src/basic_hierarchy/common/HierarchyBuilder.java
@@ -88,7 +88,7 @@ public class HierarchyBuilder
         createParentChildRelations( nodes, progressReporter );
 
         statusMsg = "Fixing depth gaps...";
-        nodes.addAll( fixDepthGaps( nodes, useSubtree, progressReporter ) );
+        nodes.addAll( fixDepthGaps( nodes, root.getId(), useSubtree, progressReporter ) );
 
         if ( fixBreadthGaps ) {
             progress = -1;
@@ -228,13 +228,15 @@ public class HierarchyBuilder
      * 
      * @param nodes
      *            the original collection of nodes
+     * @param rootId
+     *            id of the root node
      * @param useSubtree
      *            whether the centroid calculation should also include child nodes' instances
      * @param progressReporter
      *            function used to report progress of this operation. Can be null.
      * @return collection of artificial nodes created as a result of this method
      */
-    public static List<BasicNode> fixDepthGaps( List<BasicNode> nodes, boolean useSubtree, Consumer<Integer> progressReporter )
+    public static List<BasicNode> fixDepthGaps( List<BasicNode> nodes, String rootId, boolean useSubtree, Consumer<Integer> progressReporter )
     {
         if ( progressReporter != null )
             progressReporter.accept( 0 );
@@ -254,7 +256,7 @@ public class HierarchyBuilder
                 progressReporter.accept( (int)( 100 * ( (double)i / total ) ) );
             BasicNode node = nodes.get( i );
 
-            if ( node.getId().equals( Constants.ROOT_ID ) ) {
+            if ( node.getId().equals( rootId ) ) {
                 // Don't consider the root node.
                 continue;
             }

--- a/src/basic_hierarchy/implementation/BasicHierarchy.java
+++ b/src/basic_hierarchy/implementation/BasicHierarchy.java
@@ -38,11 +38,12 @@ public class BasicHierarchy implements Hierarchy
         this.dataNames = dataNames == null ? null : Arrays.copyOf( dataNames, dataNames.length );
         this.groups = nodes.toArray( new BasicNode[nodes.size()] );
 
-        boolean withTrueClass = root.getSubtreeInstances().get( 0 ).getTrueClass() != null;
+        List<Instance> instances = root.getSubtreeInstances();
+        boolean withTrueClass = instances.isEmpty() || instances.get( 0 ).getTrueClass() != null;
 
         Map<String, Integer> eachClassWithCount = new HashMap<>();
         for ( Node n : nodes ) {
-            List<Instance> instances = n.getNodeInstances();
+            instances = n.getNodeInstances();
             this.overallNumberOfInstances += instances.size();
 
             if ( !withTrueClass )

--- a/src/basic_hierarchy/implementation/BasicHierarchy.java
+++ b/src/basic_hierarchy/implementation/BasicHierarchy.java
@@ -26,21 +26,14 @@ public class BasicHierarchy implements Hierarchy
      * information possible (instances, parent-child relations, true class, etc.)
      * 
      * @param nodes
-     *            list of all nodes comprising this hierarchy
+     *            list of all nodes comprising this hierarchy.
+     *            This list must be sorted in ascending order by nodes' ids.
      * @param dataNames
      *            names for instance features. Can be null.
      */
     public BasicHierarchy( List<? extends Node> nodes, String[] dataNames )
     {
-        for ( Node n : nodes ) {
-            if ( n.getParent() == null ) {
-                root = n;
-                break;
-            }
-        }
-        if ( root == null ) {
-            throw new IllegalArgumentException( "Node collection does not contain a root node." );
-        }
+        root = nodes.get( 0 );
 
         this.dataNames = dataNames == null ? null : Arrays.copyOf( dataNames, dataNames.length );
         this.groups = nodes.toArray( new BasicNode[nodes.size()] );

--- a/src/basic_hierarchy/test/implementation/HierarchyBuilderTest.java
+++ b/src/basic_hierarchy/test/implementation/HierarchyBuilderTest.java
@@ -70,7 +70,7 @@ public class HierarchyBuilderTest
         // Creates:
         // - gen.0.0
         // - gen.0.0.11
-        List<BasicNode> artificial = HierarchyBuilder.fixDepthGaps( nodes, false, null );
+        List<BasicNode> artificial = HierarchyBuilder.fixDepthGaps( nodes, Constants.ROOT_ID, false, null );
 
         // Assert that no unexpected nodes have been created
         Assert.assertEquals( 2, artificial.size() );
@@ -105,7 +105,7 @@ public class HierarchyBuilderTest
         // Creates:
         // - gen.0.0
         // - gen.0.0.11
-        List<BasicNode> artificialDepth = HierarchyBuilder.fixDepthGaps( nodes, false, null );
+        List<BasicNode> artificialDepth = HierarchyBuilder.fixDepthGaps( nodes, Constants.ROOT_ID, false, null );
 
         // Creates:
         // - gen.0.0.[0-9]


### PR DESCRIPTION
- Files that list instances not in depth-first order are now loaded correctly.
- Fixed `fixDepthGaps` failing for hierarchies whose root was not gen.0
- Added convenience constructor to `BasicHierarchy`
- Children of `BasicNode` are now sorted in ascending order